### PR TITLE
Add no-else-return and update no-unused-vars and keyword-spacing

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -12,6 +12,9 @@ module.exports = {
 		// require the use of === and !==
 		"eqeqeq": "error",
 
+		// disallow `else` blocks after `return` statements in `if` statements
+		"no-else-return": "error",
+
 		// disallow the use of eval()
 		"no-eval": "error",
 

--- a/rules/style.js
+++ b/rules/style.js
@@ -104,6 +104,10 @@ module.exports = {
 				"catch": {
 					"before": false,
 					"after": false
+				},
+				"this": {
+					"before": true,
+					"after": false
 				}
 			}
 		}],

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -5,7 +5,7 @@ module.exports = {
 	rules: {
 		// disallow unused variables
 		"no-unused-vars": ["error", {
-			"ignore-rest-siblings": true
+			"ignoreRestSiblings": true
 		}]
 	}
 };

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -3,6 +3,9 @@
 
 module.exports = {
 	rules: {
-
+		// disallow unused variables
+		"no-unused-vars": ["error", {
+			"ignore-rest-siblings": true
+		}]
 	}
 };


### PR DESCRIPTION
#### Sets `no-else-return` to error
An example of previously working code that will now have an error:
```javascript
if(condition){
	return false;
}else{
	return true;
}
```
Example of working code with this rule:
```javascript
if(condition){
	return false;
}
return true;
```


#### Sets the `ignoreRestSiblings` option to true for the `no-unused-vars` rule
An example of code that would previously have an error but would now work:
```javascript
const {unused, ...options} = opts;
```

Example of code that would work before this change:
```javascript
const {...options} = opts;
delete options.unused;
```


#### Adds `this: {before: true, after: false}` to the `overrides` option of `keyword-spacing`
An example of code that would previously have an error but would now work:
```javascript
if(this.index > this.highestIndex){
	this.highestIndex = this.index;
}
```

An attempted solution that has an error due to `space-infix-ops`:
```javascript
if(this.index >this.highestIndex{
	this.highestIndex = this.index;
}
```

Example of code that would work before this change:
```javascript
let highestIndex = this.highestIndex;
if(this.index > highestIndex){
	this.highestIndex = this.index;
}
```